### PR TITLE
商品詳細表示機能の実装

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,5 +1,5 @@
 class ItemsController < ApplicationController
-  before_action :authenticate_user!, except: [:index]
+  before_action :authenticate_user!, except: [:index, :show]
   def index
     @items = Item.all.order("created_at DESC")
   end

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -16,6 +16,11 @@ class ItemsController < ApplicationController
       render :new
     end
   end
+
+  def show
+    @item = Item.find(params[:id])
+  end
+
   private
   def item_params
     params.require(:item).permit(:image, :title, :explain, :category_id, :condition_id, :s_fee_id, :area_id, :d_f_ship_id, :price).merge(user_id: current_user.id)

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -119,10 +119,10 @@
       
       <% @items.each do |item| %>
       <li class='list'>
-          <%= link_to "#" do %>
+          <%= link_to (item_path(item)) do %>
           <div class='item-img-content'>
             <%= image_tag item.image, class: "item-img" %>
-
+            
           </div>
           <div class='item-info'>
             <h3 class='item-name'>

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -1,40 +1,34 @@
-<%= render "shared/header" %>
+<%= render "devise/shared/header" %>
 
-<%# 商品の概要 %>
 <div class="item-show">
   <div class="item-box">
     <h2 class="name">
-      <%= "商品名" %>
+      <%= @item.title %>
     </h2>
     <div class='item-img-content'>
-      <%= image_tag "item-sample.png" ,class:"item-box-img" %>
-      <%# 商品が売れている場合は、sold outを表示しましょう %>
-      <div class='sold-out'>
-        <span>Sold Out!!</span>
-      </div>
-      <%# //商品が売れている場合は、sold outを表示しましょう %>
+      <%= image_tag @item.image ,class:"item-box-img" %>
+
+
     </div>
     <div class="item-price-box">
       <span class="item-price">
-        ¥ 999,999,999
+       <%= "¥ #{@item.price}" %>
       </span>
       <span class="item-postage">
-        <%= '配送料負担' %>
+        <%= @item.s_fee.name %>
       </span>
     </div>
 
-    <%# ログインしているユーザーと出品しているユーザーが、同一人物の場合と同一人物ではない場合で、処理を分けましょう %>
-
+    <% if user_signed_in? && current_user.id == @item.user_id%>
     <%= link_to '商品の編集', "#", method: :get, class: "item-red-btn" %>
     <p class='or-text'>or</p>
     <%= link_to '削除', "#", method: :delete, class:'item-destroy' %>
-
+    <% elsif user_signed_in? %>
     <%# 商品が売れていない場合はこちらを表示しましょう %>
     <%= link_to '購入画面に進む', "#" ,class:"item-red-btn"%>
     <%# //商品が売れていない場合はこちらを表示しましょう %>
-
-
-    <%# //ログインしているユーザーと出品しているユーザーが、同一人物の場合と同一人物ではない場合で、処理を分けましょう %>
+    <% else %>
+    <% end %>
 
     <div class="item-explain-box">
       <span><%= "商品説明" %></span>
@@ -43,27 +37,27 @@
       <tbody>
         <tr>
           <th class="detail-item">出品者</th>
-          <td class="detail-value"><%= "出品者名" %></td>
+          <td class="detail-value"><%= @item.user.nickname %></td>
         </tr>
         <tr>
           <th class="detail-item">カテゴリー</th>
-          <td class="detail-value"><%= "カテゴリー名" %></td>
+          <td class="detail-value"><%= @item.category.name %></td>
         </tr>
         <tr>
           <th class="detail-item">商品の状態</th>
-          <td class="detail-value"><%= "商品の状態" %></td>
+          <td class="detail-value"><%= @item.condition.name %></td>
         </tr>
         <tr>
           <th class="detail-item">配送料の負担</th>
-          <td class="detail-value"><%= "発送料の負担" %></td>
+          <td class="detail-value"><%= @item.s_fee.name %></td>
         </tr>
         <tr>
           <th class="detail-item">発送元の地域</th>
-          <td class="detail-value"><%= "発送元の地域" %></td>
+          <td class="detail-value"><%= @item.area.name %></td>
         </tr>
         <tr>
           <th class="detail-item">発送日の目安</th>
-          <td class="detail-value"><%= "発送日の目安" %></td>
+          <td class="detail-value"><%= @item.d_f_ship.name %></td>
         </tr>
       </tbody>
     </table>
@@ -78,7 +72,6 @@
       </div>
     </div>
   </div>
-  <%# /商品の概要 %>
 
   <div class="comment-box">
     <form>
@@ -102,9 +95,7 @@
       後ろの商品 ＞
     </a>
   </div>
-  <%# 詳細ページで表示されている商品のカテゴリー名を表示しましょう %>
-  <a href=“#” class=‘another-item’><%= "商品のカテゴリー名" %>をもっと見る</a>
-  <%# //詳細ページで表示されている商品のカテゴリー名を表示しましょう %>
+  <a href=“#” class=‘another-item’><%= @item.category.name %>をもっと見る</a>
 </div>
 
-<%= render "shared/footer" %>
+<%= render "devise/shared/footer" %>


### PR DESCRIPTION
# 商品詳細表示機能の実装

# 商品詳細表示機能実装のため

○挙動
・サインイン && 出品者が閲覧した場合(ユーザー名:sample)
https://gyazo.com/4eb52e34dccea24f735d6e8fea793421

・サインイン && 出品者以外が閲覧した場合(ユーザー名：sample2)
https://gyazo.com/0cf3d3a3e452b63d952bc54c316affb1

・サインアウトしているユーザーが閲覧した場合
https://gyazo.com/e2bbcfef475dd10f32258d142da3dac2

商品購入機能は未実装のため実施要件の
・ログイン状態の出品者でも、売却済みの商品に対しては「編集・削除ボタン」が表示されないこと
・売却済みの商品は、画像上に「sold out」の文字が表示されるようになっていること
上記項目は未実装です。

コードレビューの方、よろしくお願い致します。